### PR TITLE
get records by their default language_code as settled over language method

### DIFF
--- a/nece/managers.py
+++ b/nece/managers.py
@@ -77,5 +77,7 @@ class TranslationManager(models.Manager, TranslationMixin):
 
     def language(self, language_code):
         language_code = self.get_language_key(language_code)
+        if self.is_default_language(language_code):
+            return self.language_or_default(language_code)
         return self.language_or_default(language_code).filter(
             translations__has_key=(language_code))


### PR DESCRIPTION
In this PR, I would like to raise concern over `language` method in `nece/managers.py` which does not support to retrieve records by  default `language_code` even it's settled in `TRANSLATIONS_DEFAULT` and we assume that the records are going to be saved via present default `language_code`. Therefore when we query records by default `language_code` that would bring the records because we've already decided that language will be their base/first one.

Before 

``` bash
In [7]: Animal.objects.language('en_us')
Out[7]: []
```

After 

``` bash
In [8]: Animal.objects.language('en_us')
Out[8]: [<Animal: cat>, <Animal: dolphin>]
```
