### PR TITLE
fix pickling by using a conventional class instead of namedtuple

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst') as f:
 
 long_description = ld.replace(ld[0:ld.find('nece?')], '')
 
-version = '0.4.7'
+version = '0.4.8'
 description = "A content translation framework using Postgresql's jsonb" + \
     " field in the background"
 url = 'https://github.com/tatterdemalion/django-nece'


### PR DESCRIPTION
`PicklingError: Can't pickle <class 'nece.models.Language'>: it's not found as nece.models.Language`

`pickle` tries to find a `Language` class in the module but `namedtuple`'s are created on the fly. This is a quick&dirty solution to the problem. It may not be as optimized as `namedtuple`'s but fixes the problem at the moment. We may need to refactor the code in the future.
