### PR TITLE
Detect features instead of checking Django version

### DIFF
--- a/nece/managers.py
+++ b/nece/managers.py
@@ -1,11 +1,9 @@
 from django.db import models
-from distutils.version import StrictVersion
-from django import get_version
 from django.conf import settings
 
-if StrictVersion(get_version()) >= StrictVersion('1.9.0'):
+try:
     from django.db.models.query import ModelIterable
-else:
+except ImportError:
     ModelIterable = object  # just mocking it
 
 

--- a/nece/models.py
+++ b/nece/models.py
@@ -1,15 +1,13 @@
 from __future__ import unicode_literals
 
-from distutils.version import StrictVersion
-from django import get_version
 from django.db import models
 from django.db.models import options
 from nece.managers import TranslationManager, TranslationMixin
 from nece.exceptions import NonTranslatableFieldError
 
-if StrictVersion(get_version()) >= StrictVersion('1.9.0'):
+try:
     from django.contrib.postgres.fields import JSONField
-else:
+except ImportError:
     from nece.fields.pgjson import JSONField
 
 options.DEFAULT_NAMES += ('translatable_fields',)


### PR DESCRIPTION
Merhaba!

First of all, thank you for your work on `nece`, it's a very elegant design, my teammates and myself are looking forward to using it in our projects instead of other, more cumbersome content translation engines ;)

I just ran into a little problem though. An edge case, really.
At the moment we have to work with the `master` branch of Django, in which `get_version` returns something like `1.11.dev20160811092707`. That does not play well with `StrictVersion`.

Instead of relying on this mechanism, I suggest to use a `try/except` block to import what we need and fallback, if necessary, on what's actually available :)
