### PR TITLE
setup: don't require a pinned version of six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     install_requires=[
         'Django>=1.9',
         'psycopg2>=2.5.4',
-        'six==1.10.0',
+        'six>=1.10.0',
     ],
     license='BSD License',
     classifiers=[


### PR DESCRIPTION
Hi,

As a library, nece cannot force a fixed version of a dependency, you cannot know in advance in what environment nece will integrate.

Please do a patch release with this commit, thanks in advance.