### PR TITLE
Add fallback language support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -179,6 +179,20 @@ Default:
     {'en': 'en_us'}
 
 
+TRANSLATIONS_FALLBACK
+~~~~~~~~~~~~~~~~~~~~~
+
+Fallback language would be used if a translation is missing.
+
+Example:
+
+::
+    TRANSLATIONS_FALLBACK = {
+        'fr_ca': ['fr_fr'],
+        'en_us': ['en_gb'],
+    }
+
+
 
 Contributors & Thanks
 ---------------------

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -12,6 +12,10 @@ def get_fixtures(n=None):
                     "benefits": "gut für die Feuerstelle",
                     "name": "Apfel"
                 },
+                "fr_fr": {
+                    "benefits": "bon pour la santé",
+                    "name": "pomme"
+                },
                 "ku_tr": {
                     "name": "sêv"
                 },

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -17,3 +17,4 @@ DATABASES = {
 INSTALLED_APPS = ('nece', 'tests',)
 TRANSLATIONS_DEFAULT = 'en_us'
 TRANSLATIONS_MAP = {'en': 'en_us', 'tr': 'tr_tr', 'de': 'de_de', 'it': 'it_it'}
+TRANSLATIONS_FALLBACK = {'fr_ca': ['fr_fr'], 'en_us': ['en_gb']}


### PR DESCRIPTION
Ref: https://github.com/tatterdemalion/django-nece/issues/28

A fallback option (True by default) is available when retrieving an object's translated field.

```
# settings.py
TRANSLATIONS_FALLBACK = {'fr_ca': ['fr_fr'], 'en_us': ['en_gb']}

# console
>> f = Fruit.objects.get(name='苹果', translations=
        {'de_de': {'name': 'Apfel'},
         'fr_fr': {'name': 'pomme'},)

>> f.language('fr_ca')
'pomme'
>> f.language('fr_ca', fallback=False)
'apple'
```

Note that the fallback option is not aiming for queries: a query represents a sql and it should be as explicit as possible.