### PR TITLE
Fix UnicodeDecodeError on Windows on installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@
 from setuptools import setup
 
 
-with open('README.rst') as f:
-    ld = f.read()
+with open('README.rst', 'rb') as f:
+    ld = f.read().decode('utf8')
 
 long_description = ld.replace(ld[0:ld.find('nece?')], '')
 


### PR DESCRIPTION
I got this error
```
C:\nece
λ python setup.py install
Traceback (most recent call last):
  File "setup.py", line 6, in <module>
    ld = f.read()
  File "C:\Python\Python35\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 675: character maps to <undefined>
```
