### PR TITLE
Update psycopg2 dependeny in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=['nece'],
     install_requires=[
         'Django>=1.9',
-        'psycopg2>=2.5.4',
+        'psycopg2-binary>=2.8.1',
         'six>=1.10.0',
     ],
     license='BSD License',


### PR DESCRIPTION
psycop2 dependency must be updated to "psycopg2-binary" in order to install nece