### PR TITLE
Fix bug that lead to always using the fallback language, if available

### DIFF
--- a/nece/models.py
+++ b/nece/models.py
@@ -89,7 +89,7 @@ class TranslationModel(models.Model, TranslationMixin):
                     self._language_code = code
                     trans = self.populate_translations(translations)
                     self._translated = Language(**trans)
-                    continue
+                    break
 
         return self
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -22,7 +22,11 @@ def get_fixtures(n=None):
                 "tr_tr": {
                     "benefits": "Kalbe yararlıdır",
                     "name": "elma"
-                }
+                },
+                "en_us": {
+                    "benefits": "there are benefits",
+                    "name": "new york"
+                },
             },
             "name": "apple",
             "benefits": "good for health",


### PR DESCRIPTION
There's a bug in the language selection algorithm that makes is always select the fallback if it exists. This commit adds a test fixture exposing the bug and fixes it.

Root cause is that `continue` is a no-op at the end of a loop, since it means "continue with next iteration of loop". You must have meant `break` instead :)