### PR TITLE
TranslationModel.translate: Always write a translation in the jsonb f…

### DIFF
--- a/nece/models.py
+++ b/nece/models.py
@@ -48,18 +48,16 @@ class TranslationModel(models.Model, TranslationMixin):
     def translate(self, language_code=None, **kwargs):
         if language_code:
             self._language_code = language_code
-        if not self.is_default_language(self._language_code):
-            self.translations = self.translations or {}
-            self.translations[self._language_code] = self.translations.get(
-                self._language_code, {}
-            )
+        self.translations = self.translations or {}
+        self.translations[self._language_code] = self.translations.get(
+            self._language_code, {}
+        )
         for name, value in kwargs.items():
             if name not in self._meta.translatable_fields:
                 raise NonTranslatableFieldError(name)
             if self.is_default_language(self._language_code):
                 setattr(self, name, value)
-            else:
-                self.translations.get(self._language_code, {})[name] = value
+            self.translations.get(self._language_code, {})[name] = value
         if language_code:
             self.language(language_code)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -120,6 +120,21 @@ class TranslationTest(TestCase):
         self.assertEqual(names.count(), Fruit.objects.count())
         self.assertEqual(len(names), Fruit.objects.count())
 
+    def test_save_translation_in_jsonb_for_default_language(self):
+        fruit = Fruit.objects.get(name='apple')
+        default_lang = fruit._default_language_code
+        default_name = (
+            f"I should be stored in fruit.name"
+            f"and in fruit.translations['{default_lang}']['name']"
+        )
+        fruit.translate(default_lang, name=default_name)
+        fruit.language(default_lang)
+
+        # In the current name attribute
+        self.assertEqual(fruit.name, default_name)
+        # In jsonb translations field
+        self.assertEqual(fruit.translations[default_lang]['name'], default_name)
+
 
 class TranslationOrderingTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
TranslationModel.translate: Always write a translation in the jsonb field

Currently, in the translate function of TranslationModel, the `translations` dict is not created if we try to translate the default language.

The suggestion is to always create the `translations` jsonb field, and always write inside, even for the default language.

Thus, all the languages are stored equally and the jsonb field always contains all the available translations. If the default language is changed later in the project, the default translation is kept and still available in the jsonb `translations` field.

The original attribute is still written in, as a shortcut for accessing the default language.

This could also simplify data migrations from one translation framework to nece, by copying every existing old translations into a jsonb `translations` field, to prepare the terrain for nece. 
